### PR TITLE
Implement const tagging

### DIFF
--- a/xdrgen/examples/example.x
+++ b/xdrgen/examples/example.x
@@ -3,6 +3,8 @@ struct Bar {
        opaque data<>;
 };
 typedef Bar BarPair[2];
+
+const VERSION_0 = 0;
 struct Foo {
 	int a; /* comment a */
 	int b;
@@ -14,6 +16,8 @@ struct Foo {
 	Things thing;
 	unsigned type;
 };
+
+const VERSION_1 = 1;
 union Foobar switch (Things t) {
 	case A:
 		int a;

--- a/xdrgen/examples/pretty/Cargo.toml
+++ b/xdrgen/examples/pretty/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [dependencies.xdr-codec]
 path = "../../../xdr-codec"
 
+[build-dependencies]
+quote = "1"
+
 [build-dependencies.xdrgen]
 path = "../.."
 features = ["pretty"]

--- a/xdrgen/examples/pretty/build.rs
+++ b/xdrgen/examples/pretty/build.rs
@@ -1,3 +1,6 @@
+use xdrgen::pretty::{GenerateOptions, ConstTaggingOptions};
+use quote::quote;
+
 extern crate xdrgen;
 
 fn main() {
@@ -7,7 +10,15 @@ fn main() {
         #![allow(dead_code)]
         use xdr_codec;
     ";
-    let output = xdrgen::generate_pretty(&input, header, &[]).unwrap();
+    let tagging = Some(ConstTaggingOptions {
+        const_filter: |name| name.starts_with("VERSION_"),
+        quote: |ty, tag| quote!(
+            impl crate::Versioned for #ty {
+                const VERSION: i64 = #tag;
+            }
+        ),
+    });
+    let output = xdrgen::generate_pretty(&input, &GenerateOptions{header, tagging, ..Default::default()}).unwrap();
     std::fs::create_dir_all("generated").unwrap();
     std::fs::write("generated/pretty_xdr.rs", output).unwrap();
 }

--- a/xdrgen/examples/pretty/src/main.rs
+++ b/xdrgen/examples/pretty/src/main.rs
@@ -6,6 +6,10 @@ use xdr_codec::{unpack,pack};
 #[path ="../generated/pretty_xdr.rs"]
 mod xdr;
 
+trait Versioned {
+    const VERSION: i64;
+}
+
 fn main() {
     let bar = xdr::Bar { data: vec![1,2,3] };
     let foo = xdr::Foo {
@@ -31,4 +35,7 @@ fn main() {
     println!("foobar={:?}", foobar);
     println!("foobar2={:?}", foobar2);
     assert_eq!(foobar, foobar2);
+
+    assert_eq!(xdr::Foo::VERSION, 0);
+    assert_eq!(xdr::Foobar::VERSION, 1);
 }

--- a/xdrgen/src/spec/mod.rs
+++ b/xdrgen/src/spec/mod.rs
@@ -108,7 +108,7 @@ lazy_static! {
     };
 }
 
-fn quote_ident<S: AsRef<str>>(id: S) -> Ident {
+pub(crate) fn quote_ident<S: AsRef<str>>(id: S) -> Ident {
     let id = id.as_ref();
 
     if (*KEYWORDS).contains(id) {


### PR DESCRIPTION
Once specific `const` encountered in input file - start to generate quote fragments with such const-tag for each type, until next const-tag.